### PR TITLE
Add Parameter 12 for dimmers

### DIFF
--- a/devicetypes/inovelliusa/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
+++ b/devicetypes/inovelliusa/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
@@ -435,7 +435,7 @@ def getParameter(number) {
 }
 
 def getParameterNumbers(){
-    return [1,2,3,4,5,6,7,8,9,10,11,13,14,15,17,21,22,51,52]
+    return [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,21,22,51,52]
 }
 
 def getParameterInfo(number, value){

--- a/devicetypes/inovelliusa/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
+++ b/devicetypes/inovelliusa/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
@@ -884,7 +884,7 @@ def getParameter(number) {
 }
 
 def getParameterNumbers(){
-    return [1,2,3,4,5,6,7,8,9,10,11,13,14,15,17,18,19,20,21,22,51,52]
+    return [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,18,19,20,21,22,51,52]
 }
 
 def getParameterInfo(number, value){


### PR DESCRIPTION
Parameter 12 (Association Behavior) was missing from the getParameterNumbers() list in the DTH for both dimmers (LZW31 and LZW31-SN). All the other code for this parameter appears to be present already.
